### PR TITLE
Remove Berkeley DB dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -561,16 +561,6 @@
           <version>2.9-SNAPSHOT</version>
         </dependency>
         <dependency>
-          <groupId>org.locationtech.geogig</groupId>
-          <artifactId>geogig-bdbje</artifactId>
-          <version>1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-          <groupId>com.sleepycat</groupId>
-          <artifactId>je</artifactId>
-          <version>5.0.84</version>
-        </dependency>
-        <dependency>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpcore</artifactId>
           <version>4.2.5</version>


### PR DESCRIPTION
  Remove BDB jars as they are no longer built with core GeoGig.
  If BDB backed repos are desired, you can get them from building:

  https://github.com/boundlessgeo/geogig-plugins/