### PR TITLE
Geoserver 2.12 updates

### DIFF
--- a/geoserver/pom.xml
+++ b/geoserver/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.opengeo</groupId>
 	<artifactId>geonode-geoserver-ext</artifactId>
 	<packaging>pom</packaging>
-	<version>2.12.0</version>
+	<version>2.12.1</version>
 	<name>GeoNode GeoServer Extensions</name>
 
 	<repositories>
@@ -53,7 +53,6 @@
       <url>https://s3.amazonaws.com/boundlessps-public/main/</url>
     </repository>
 	</repositories>
-
     <distributionManagement>
         <!-- repository>
          <id>boundless</id>
@@ -78,7 +77,7 @@
           <url>scp://demo.geo-solutions.it/var/www/share/github/gsman</url>
         </site>
     </distributionManagement>
- 
+
 	<dependencyManagement>
 		<dependencies>
             <dependency>
@@ -145,7 +144,6 @@
 				<version>${gs.community.version}</version>
 			</dependency>
       -->
-      
 			<dependency>
 				<groupId>org.geoserver.community.backuprestore</groupId>
 				<artifactId>gs-backup-restore-core</artifactId>
@@ -191,7 +189,7 @@
 			</dependency>
       -->
 			<!-- other dependencies -->
-      
+
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>
@@ -373,7 +371,7 @@
 
 			<dependency>
 				<groupId>org.opengeo.geoserver</groupId>
-				<artifactId>printng</artifactId> 
+				<artifactId>printng</artifactId>
 				<version>${project.version}</version>
                 <scope>runtime</scope>
 				<exclusions>
@@ -432,7 +430,7 @@
 			<dependency>
 				<groupId>org.geoserver.community</groupId>
 				<artifactId>gs-geofence</artifactId>
-				<version>2.12-SNAPSHOT</version>
+				<version>${gs.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.geoserver.community</groupId>
@@ -470,11 +468,10 @@
           <version>${gt.version}</version>
 			</dependency>
 
-			<!-- Updated geogit to geogig -->
 		<dependency>
 			<groupId>org.geoserver.community</groupId>
 			<artifactId>gs-geogig</artifactId>
-			<version>2.12-SNAPSHOT</version>
+      <version>2.12-SNAPSHOT</version>
 		</dependency>
 				<!-- Use newer version of H2 to solve issues with geofence -->
           <dependency>
@@ -508,9 +505,9 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<geoserver.data.dir>exchange</geoserver.data.dir>
-        <gt.version>18.0</gt.version>
-		<gs.version>2.12.0</gs.version>
-		<gs.community.version>2.12.0</gs.community.version>
+        <gt.version>18.1</gt.version>
+		<gs.version>2.12.1</gs.version>
+		<gs.community.version>2.12.1</gs.community.version>
         <gf.version>3.2-SNAPSHOT</gf.version>
 		<jetty.servlet.api.version>3.1.0</jetty.servlet.api.version>
 <!--
@@ -552,7 +549,7 @@
 		</resources>
 		<plugins>
 			<plugin>
-				<!-- injects git information like current branch and commit id as maven 
+				<!-- injects git information like current branch and commit id as maven
 					properties -->
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>

--- a/geoserver/web-app/pom.xml
+++ b/geoserver/web-app/pom.xml
@@ -272,13 +272,10 @@
             </exclusions>
 		</dependency>
 
-		<!-- Updated geogit to geogig -->
-    <!-- Commenting out gs-geogig because of an issue with spring-mvc
 		<dependency>
 			<groupId>org.geoserver.community</groupId>
 			<artifactId>gs-geogig</artifactId>
 		</dependency>
-    -->
 
 		<!-- Other GeoServer Extensions -->
         <dependency>

--- a/geoserver/web-app/pom.xml
+++ b/geoserver/web-app/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.opengeo</groupId>
 		<artifactId>geonode-geoserver-ext</artifactId>
-		<version>2.12.0</version>
+		<version>2.12.1</version>
 	</parent>
 	<groupId>org.opengeo</groupId>
 	<artifactId>geonode-geoserver-ext-web-app</artifactId>


### PR DESCRIPTION
* incremented the GeoServer and GeoTools versions to the latest stable releases
* incremented the patch version for the `geonode-geoserver-ext` artifact 

I left the 2.12-SNAPSHOT versions for the dependencies for `gs-geofence-server` and `gs-geogig` b/c they don't have published versions for 2.12.1 yet.